### PR TITLE
Refactor \ code re-use.

### DIFF
--- a/src/components/localtunneldebugger/localtunneldebugger.ts
+++ b/src/components/localtunneldebugger/localtunneldebugger.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-
 import { LocalTunnelDebugProvider } from './localtunneldebugger.extension';
 import { getLocalTunnelDebugProvider } from '../config/config';
 
@@ -15,17 +14,21 @@ export class LocalTunnelDebugger {
         const providerName: string | undefined = getLocalTunnelDebugProvider() ?? this.providers.map((p) => p.id).sort()[0];
         const providerToUse: LocalTunnelDebugProvider | undefined = this.providers.find((p) => p.id === providerName);
 
-        if (this.providers.length === 0) {
-            const message = 'You do not have a Local Tunnel Debug Provider installed.';
-            LocalTunnelDebugger.displayUIandExecuteCommand(message);
-        }
-
-        if (providerToUse === undefined) {
-            const message = `You have configured VSCode to use Local Tunnel debugger '${providerName}', but it is not installed.`;
-            LocalTunnelDebugger.displayUIandExecuteCommand(message);
-        } else {
+        // On success start early.
+        if (this.providers.length && providerToUse) {
             providerToUse.startDebugging(target);
         }
+
+        // Handle failure scenarios.
+        let message = 'You do not have a Local Tunnel Debug Provider installed.';
+        if (this.providers.length === 0) {
+            message = 'You do not have a Local Tunnel Debug Provider installed.';
+        }
+        if (providerToUse === undefined) {
+            message = `You have configured VSCode to use Local Tunnel debugger '${providerName}', but it is not installed.`;
+        }
+
+        LocalTunnelDebugger.displayUIandExecuteCommand(message);
     };
 
     static displayUIandExecuteCommand(message: string) {

--- a/src/components/localtunneldebugger/localtunneldebugger.ts
+++ b/src/components/localtunneldebugger/localtunneldebugger.ts
@@ -12,34 +12,32 @@ export class LocalTunnelDebugger {
     }
 
     startLocalTunnelDebugProvider(target?: any): void {
-        const browseExtensions = "Find Providers on Marketplace";
+        const providerName: string | undefined = getLocalTunnelDebugProvider() ?? this.providers.map((p) => p.id).sort()[0];
+        const providerToUse: LocalTunnelDebugProvider | undefined = this.providers.find((p) => p.id === providerName);
+
         if (this.providers.length === 0) {
-            vscode.window.showInformationMessage('You do not have a Local Tunnel Debug Provider installed.', browseExtensions)
-            .then((selection: string | undefined) => {
-                if (selection === browseExtensions) {
-                    vscode.commands.executeCommand('extension.vsKubernetesFindLocalTunnelDebugProviders');
-                }
-            });
-            return;
+            const message = 'You do not have a Local Tunnel Debug Provider installed.';
+            LocalTunnelDebugger.displayUIandExecuteCommand(message);
         }
 
-        let providerName: string | undefined = getLocalTunnelDebugProvider();
-        if (!providerName) {
-            // If no provider is configured in the settings, take the first one that's registered
-            providerName = this.providers.map((p) => p.id).sort()[0];
-        }
-        const providerToUse: LocalTunnelDebugProvider | undefined = this.providers.find((p) => p.id === providerName);
         if (providerToUse === undefined) {
-            vscode.window.showWarningMessage(`You have configured VSCode to use Local Tunnel debugger '${providerName}', but it is not installed.`, browseExtensions)
+            const message = `You have configured VSCode to use Local Tunnel debugger '${providerName}', but it is not installed.`;
+            LocalTunnelDebugger.displayUIandExecuteCommand(message);
+        } else {
+            providerToUse.startDebugging(target);
+        }
+    };
+
+    static displayUIandExecuteCommand(message: string) {
+        const browseExtensions = "Find Providers on Marketplace";
+
+        vscode.window.showInformationMessage(message, browseExtensions)
             .then((selection: string | undefined) => {
                 if (selection === browseExtensions) {
                     vscode.commands.executeCommand('extension.vsKubernetesFindLocalTunnelDebugProviders');
                 }
             });
-            return;
-        }
-        providerToUse.startDebugging(target);
-    };
+    }
 }
 
 

--- a/src/components/localtunneldebugger/localtunneldebugger.ts
+++ b/src/components/localtunneldebugger/localtunneldebugger.ts
@@ -5,12 +5,12 @@ import { getLocalTunnelDebugProvider } from '../config/config';
 export class LocalTunnelDebugger {
     private readonly providers = Array.of<LocalTunnelDebugProvider>();
 
-    register(provider: LocalTunnelDebugProvider): void {
+    register(provider: LocalTunnelDebugProvider) {
         console.log(`Registered local tunnel debugger type ${provider.id}`);
         this.providers.push(provider);
     }
 
-    startLocalTunnelDebugProvider(target?: any): void {
+    startLocalTunnelDebugProvider(target?: any) {
         const providerName: string | undefined = getLocalTunnelDebugProvider() ?? this.providers.map((p) => p.id).sort()[0];
         const providerToUse: LocalTunnelDebugProvider | undefined = this.providers.find((p) => p.id === providerName);
 
@@ -20,11 +20,11 @@ export class LocalTunnelDebugger {
         }
 
         // Handle failure scenarios.
-        let message = 'You do not have a Local Tunnel Debug Provider installed.';
-        if (this.providers.length === 0) {
+        let message = "";
+        if (!this.providers.length) {
             message = 'You do not have a Local Tunnel Debug Provider installed.';
         }
-        if (providerToUse === undefined) {
+        if (!providerToUse) {
             message = `You have configured VSCode to use Local Tunnel debugger '${providerName}', but it is not installed.`;
         }
 


### PR DESCRIPTION
Intention of following PR is to show what I meant by various type annotation and code movement comment in the PR here.

Please feel free to test and merge it and it will start appearing here: https://github.com/Azure/vscode-kubernetes-tools/pull/851 

* On `success` start early, and on `failure` handle message and display based on the type.
* Essentially I have reused the `InformationMessage` and then reused rest of the functionality to flow through that `UIandExecute` Command.
* Use of ternary operator.
* Also, we can think of making more concise in case we know exactly why we treat `providerToUse === undefined` and `this.providers.length ` differently. 
* Fixed the `return` issue based on func annotation.

=) Thank you 🙏